### PR TITLE
autoStaticName check current func name

### DIFF
--- a/cl/blockctx.go
+++ b/cl/blockctx.go
@@ -24,15 +24,17 @@ const (
 // -----------------------------------------------------------------------------
 
 type funcCtx struct {
-	labels map[string]*gox.Label
-	vdefs  *gox.VarDefs
-	basel  int
-	basev  int
+	labels  map[string]*gox.Label
+	vdefs   *gox.VarDefs
+	basel   int
+	basev   int
+	orgName string
 }
 
-func newFuncCtx(pkg *gox.Package, complicated bool) *funcCtx {
+func newFuncCtx(pkg *gox.Package, complicated bool, orgName string) *funcCtx {
 	ctx := &funcCtx{
-		labels: make(map[string]*gox.Label),
+		labels:  make(map[string]*gox.Label),
+		orgName: orgName,
 	}
 	if complicated {
 		ctx.vdefs = pkg.NewVarDefs(pkg.CB().Scope())

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -437,7 +437,7 @@ func compileFunc(ctx *blockCtx, fn *ast.Node) {
 			rewritten = false
 		}
 		cb := f.BodyStart(pkg)
-		ctx.curfn = newFuncCtx(pkg, ctx.markComplicated(fnName, body))
+		ctx.curfn = newFuncCtx(pkg, ctx.markComplicated(fnName, body), origName)
 		compileSub(ctx, body)
 		checkNeedReturn(ctx, body)
 		ctx.curfn = nil

--- a/cl/multifiles.go
+++ b/cl/multifiles.go
@@ -109,6 +109,9 @@ func checkAnonyUnion(typ types.Type) (t *types.Named, ok bool) {
 }
 
 func (p *blockCtx) autoStaticName(name string) string {
+	if p.curfn != nil {
+		name = p.curfn.orgName + "_" + name
+	}
 	return "_cgos_" + name + p.baseOF
 }
 

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -158,7 +158,7 @@ void test() {
 }
 `, `func test() {
 	var a int32 = int32(255)
-	if _cgos_b == int64(-1) {
+	if _cgos_test_b == int64(-1) {
 		a = int32(3)
 	}
 }`)


### PR DESCRIPTION
static name check current func orgname `_cgos_fnName_staticName_fileBase`

fix https://github.com/goplus/c2go/issues/148 bug1

main.c
```
void a() {
  static int a = 1;
}

int main() {
  a();
}
```
c2go main.c
```
package main

import os "os"

func a() {
}

var _cgos_a_a_main int32 = int32(1)

func _cgo_main() int32 {
	a()
	return 0
}
func main() {
	os.Exit(int(_cgo_main()))
}
```