### PR TITLE
compileImplicitCastExpr: check ast.ArrayToPointerDecay rvalue use closure

### DIFF
--- a/cl/codebuild.go
+++ b/cl/codebuild.go
@@ -499,6 +499,19 @@ func arrayToElemPtr(cb *gox.CodeBuilder) {
 		Val(arr).UnaryOp(token.AND).Call(1).Call(1)
 }
 
+func arrayToElemPtrClosure(cb *gox.CodeBuilder) {
+	arr := cb.InternalStack().Pop()
+	t, _ := gox.DerefType(arr.Type)
+	elem := t.(*types.Array).Elem()
+	pkg := cb.Pkg()
+	ret := types.NewParam(token.NoPos, pkg.Types, "", ctypes.NewPointer(elem))
+	cb.NewClosure(nil, types.NewTuple(ret), false).BodyStart(pkg).
+		DefineVarStart(token.NoPos, "v").Val(arr).EndInit(1).
+		Typ(ctypes.NewPointer(elem)).Typ(ctypes.UnsafePointer).
+		Val(cb.Scope().Lookup("v")).UnaryOp(token.AND).Call(1).Call(1).Return(1).
+		End().Call(0)
+}
+
 func castToBoolExpr(cb *gox.CodeBuilder) {
 	elem := cb.InternalStack().Get(-1)
 	if t := elem.Type; isNumber(t) {

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -207,7 +207,11 @@ func compileImplicitCastExpr(ctx *blockCtx, v *ast.Node) {
 	case ast.ArrayToPointerDecay:
 		compileExpr(ctx, v.Inner[0])
 		if cb := ctx.cb; !isValist(cb.Get(-1).Type) {
-			arrayToElemPtr(cb)
+			if v.Inner[0].ValueCategory == ast.RValue {
+				arrayToElemPtrClosure(cb)
+			} else {
+				arrayToElemPtr(cb)
+			}
 		}
 	case ast.IntegralCast, ast.FloatingCast, ast.BitCast, ast.IntegralToFloating,
 		ast.FloatingToIntegral, ast.PointerToIntegral,

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -562,4 +562,31 @@ void test() {
 }`)
 }
 
+func TestArrayToPointerDecay(t *testing.T) {
+	testFunc(t, "TestArrayToPointerDecay", `
+typedef struct Test {
+	char arr[48];
+} Test;
+Test create_test() {
+	Test test = {
+		{'a', 'b'}
+	};
+	return test;
+}
+void put_test_arr(const char *arr);
+void test() {
+	put_test_arr(create_test().arr);
+	Test t;
+	put_test_arr(t.arr);
+}
+`, `func test() {
+	put_test_arr(func() *int8 {
+		v := create_test().arr
+		return (*int8)(unsafe.Pointer(&v))
+	}())
+	var t struct_Test
+	put_test_arr((*int8)(unsafe.Pointer(&t.arr)))
+}`)
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
fix https://github.com/goplus/c2go/issues/148 bug2
```
typedef struct Test {
  char arr[48];
} Test;
Test create_test() {...}
void put_test_arr(const char *arr);
int main()
{
  put_test_arr(create_test().arr);
  Test v;
  put_test_arra(v.arr);
  return 0;
}
```
create_test().arr **rvalue**/**prvalue**(clang 13) to closure
```
put_test_arr(func() *int8 {
	v := create_test().arr
	return (*int8)(unsafe.Pointer(&v))
}())
var t struct_Test
put_test_arr((*int8)(unsafe.Pointer(&t.arr)))
```

