### PR TITLE
fix binaryOp ptr-ptr

### DIFF
--- a/cl/codebuild.go
+++ b/cl/codebuild.go
@@ -387,7 +387,7 @@ func binaryOp(ctx *blockCtx, op token.Token, v *cast.Node) {
 				castPtrType(cb, tyUintptr, arg2)
 				cb.BinaryOp(token.SUB, src)
 				if elemSize != 1 {
-					cb.Val(elemSize).BinaryOp(token.MUL)
+					cb.Val(elemSize).BinaryOp(token.QUO)
 				}
 				return
 			}

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -562,4 +562,30 @@ void test() {
 }`)
 }
 
+func TestPointer(t *testing.T) {
+	testFunc(t, "testPointer", `
+void test() {
+	int *a;
+	int *b;
+	int c;
+	a>b;
+	a>=b;
+	a<b;
+	a<=b;
+	a=b;
+	a-b;
+}
+`, `func test() {
+	var a *int32
+	var b *int32
+	var c int32
+	uintptr(unsafe.Pointer(a)) > uintptr(unsafe.Pointer(b))
+	uintptr(unsafe.Pointer(a)) >= uintptr(unsafe.Pointer(b))
+	uintptr(unsafe.Pointer(a)) < uintptr(unsafe.Pointer(b))
+	uintptr(unsafe.Pointer(a)) <= uintptr(unsafe.Pointer(b))
+	a = b
+	(uintptr(unsafe.Pointer(a)) - uintptr(unsafe.Pointer(b))) / 4
+}`)
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
fix https://github.com/goplus/c2go/issues/153
```
int *a,*b;
a-b;
```
```
(uintptr(unsafe.Pointer(a)) - uintptr(unsafe.Pointer(b))) / 4
```