### PR TITLE
compileStringLiteral: support wide int32 string

### DIFF
--- a/cl/codebuild.go
+++ b/cl/codebuild.go
@@ -491,6 +491,25 @@ func stringLit(cb *gox.CodeBuilder, s string, typ types.Type) {
 	}
 }
 
+func wstringLit(cb *gox.CodeBuilder, s string, typ types.Type) {
+	var n int
+	for _, c := range s {
+		n++
+		cb.Val(c)
+	}
+	eos := true
+	if typ == nil {
+		typ = types.NewArray(types.Typ[types.Int32], int64(n+1))
+	} else if t, ok := typ.(*types.Array); ok {
+		eos = int(t.Len()) > n
+	}
+	if eos {
+		cb.Val(rune(0)).ArrayLit(typ, n+1)
+	} else {
+		cb.ArrayLit(typ, n)
+	}
+}
+
 func arrayToElemPtr(cb *gox.CodeBuilder) {
 	arr := cb.InternalStack().Pop()
 	t, _ := gox.DerefType(arr.Type)

--- a/cl/expr.go
+++ b/cl/expr.go
@@ -718,10 +718,6 @@ func decodeEscapeString(value string) (string, error) {
 		case '"': //skip
 		case '\\':
 			i++
-			if i == size {
-				buf.WriteByte(c)
-				break
-			}
 			switch r := value[i]; r {
 			case '\'', '"', '\\':
 				buf.WriteByte(r)
@@ -769,7 +765,7 @@ func decodeEscapeString(value string) (string, error) {
 					}
 				}
 				buf.WriteRune(v)
-				i += j
+				i += j - 1
 			}
 		default:
 			buf.WriteByte(c)

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -588,4 +588,14 @@ void test() {
 }`)
 }
 
+func TestWideString(t *testing.T) {
+	testFunc(t, "testWideString", `
+void test() {
+	L"\\\a\b\f\n\r\t\v\e\x1\x0104中A+-@\"\'123abcABC";
+}
+`, `func test() {
+	(*int32)(unsafe.Pointer(&[26]int32{'\\', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\x1b', '\x01', 'Ą', '中', 'A', '+', '-', '@', '"', '\'', '1', '2', '3', 'a', 'b', 'c', 'A', '\x00'}))
+}`)
+}
+
 // -----------------------------------------------------------------------------

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -592,13 +592,13 @@ func TestWideString(t *testing.T) {
 	testFunc(t, "testWideString", `
 void test() {
 	L"";
-	L"\xab\\";
+	L"\253\xab\\\u4E2D";
 	L"\\\a\b\f\n\r\t\v\e\x1\x0104中A+-@\"\'123abcABC";
 }
 `, `func test() {
 	(*int32)(unsafe.Pointer(&[1]int32{'\x00'}))
-	(*int32)(unsafe.Pointer(&[3]int32{'«', '\\', '\x00'}))
-	(*int32)(unsafe.Pointer(&[30]int32{'\\', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\x1b', '0', '0', '1', 'Ą', '中', 'A', '+', '-', '@', '"', '\'', '1', '2', '3', 'a', 'b', 'c', 'A', 'B', 'C', '\x00'}))
+	(*int32)(unsafe.Pointer(&[5]int32{'«', '«', '\\', '中', '\x00'}))
+	(*int32)(unsafe.Pointer(&[28]int32{'\\', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\x1b', '\x01', 'Ą', '中', 'A', '+', '-', '@', '"', '\'', '1', '2', '3', 'a', 'b', 'c', 'A', 'B', 'C', '\x00'}))
 }`)
 }
 

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -591,10 +591,14 @@ void test() {
 func TestWideString(t *testing.T) {
 	testFunc(t, "testWideString", `
 void test() {
+	L"";
+	L"\xab\\";
 	L"\\\a\b\f\n\r\t\v\e\x1\x0104中A+-@\"\'123abcABC";
 }
 `, `func test() {
-	(*int32)(unsafe.Pointer(&[26]int32{'\\', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\x1b', '\x01', 'Ą', '中', 'A', '+', '-', '@', '"', '\'', '1', '2', '3', 'a', 'b', 'c', 'A', '\x00'}))
+	(*int32)(unsafe.Pointer(&[1]int32{'\x00'}))
+	(*int32)(unsafe.Pointer(&[3]int32{'«', '\\', '\x00'}))
+	(*int32)(unsafe.Pointer(&[30]int32{'\\', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\x1b', '0', '0', '1', 'Ą', '中', 'A', '+', '-', '@', '"', '\'', '1', '2', '3', 'a', 'b', 'c', 'A', 'B', 'C', '\x00'}))
 }`)
 }
 


### PR DESCRIPTION
support L"" wide string to int32 array
C code
```
L"\\\a\b\f\n\r\t\v\e\x1\x0104中A+-@\"\'123abcABC";
```
Go code
```
(*int32)(unsafe.Pointer(&[28]int32{'\\', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\x1b', '\x01', 'Ą', '中', 'A', '+', '-', '@', '"', '\'', '1', '2', '3', 'a', 'b', 'c', 'A', 'B', 'C', '\x00'}))
```