### PR TITLE
compileExprEx: case ast.InitListExpr

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -72,6 +72,8 @@ func compileExprEx(ctx *blockCtx, expr *ast.Node, prompt string, flags int) {
 	case ast.VisibilityAttr:
 	case ast.CompoundLiteralExpr:
 		compileCompoundLiteralExpr(ctx, expr)
+	case ast.InitListExpr:
+		compileExprEx(ctx, expr.Inner[0], prompt, flags)
 	default:
 		log.Panicln(prompt, expr.Kind)
 	}

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -588,4 +588,17 @@ void test() {
 }`)
 }
 
+func TestInitListExpr(t *testing.T) {
+	testFunc(t, "testInitListExpr", `
+void test() {
+	int a = 255;
+	unsigned char ws = (unsigned char){a};
+	const char *buf = (const char*){"hello"};
+}`, `func test() {
+	var a int32 = int32(255)
+	var ws uint8 = uint8(a)
+	var buf *int8 = (*int8)(unsafe.Pointer(&[6]int8{'h', 'e', 'l', 'l', 'o', '\x00'}))
+}`)
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
fix https://github.com/goplus/c2go/issues/160

c code
```
const char *buf = (const char*){"hello"};
```
go code
```
var buf *int8 = (*int8)(unsafe.Pointer(&[6]int8{'h', 'e', 'l', 'l', 'o', '\x00'}))
```

**TODO**
```
 int c = 'a';
 test1(&(char){c});
 test2(&(int){c});
```