### PR TITLE
newVar: inVBlock check not in global

### DIFF
--- a/cl/blockctx.go
+++ b/cl/blockctx.go
@@ -256,14 +256,17 @@ func (p *blockCtx) lookupParent(name string) types.Object {
 
 func (p *blockCtx) newVar(scope *types.Scope, pos token.Pos, typ types.Type, name string) (ret *gox.VarDecl, inVBlock bool) {
 	cb, pkg := p.cb, p.pkg
-	if inVBlock = cb.InVBlock(); inVBlock {
+	inGlobal := scope == pkg.Types.Scope()
+	if !inGlobal {
+		inVBlock = cb.InVBlock()
+	}
+	if inVBlock {
 		var obj types.Object
 		ret, obj = p.curfn.newAutoVar(pos, typ, name)
 		if scope.Insert(gox.NewSubst(pos, pkg.Types, name, obj)) != nil {
 			log.Panicf("newVar: variable %v exists already\n", name)
 		}
 	} else {
-		inGlobal := scope == pkg.Types.Scope()
 		if inGlobal {
 			if defs, ok := p.gblvars[name]; ok {
 				defs.Delete(name)

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -588,4 +588,44 @@ void test() {
 }`)
 }
 
+func TestStaticInVblock(t *testing.T) {
+	testFunc(t, "testStaticInVblock", `
+void test() {
+	int t;
+	int *set;
+	if (t == 's') {
+		static const int spaces[] = {0};
+		set = spaces;
+	} else {
+	 goto end;
+	}
+	if (0) {
+	goto end;
+end:
+		return;
+	}
+	return;
+}`, `func test() {
+	var
+	var t int32
+	var set *int32
+	if !(t == 's') {
+		goto _cgol_2
+	}
+	set = (*int32)(unsafe.Pointer(&_cgos_test_spaces))
+	goto _cgol_1
+_cgol_2:
+	goto end
+_cgol_1:
+	if true {
+		goto _cgol_3
+	}
+	goto end
+end:
+	return
+_cgol_3:
+	return
+}`)
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
fix https://github.com/goplus/c2go/issues/165

main.c
```
int main() {
    int t = 's';
    const int *set;
    if (t == 's') {
       static const int spaces[] = {'\0'};
       set = spaces;
    } else {
       goto end;
    }
	if (0) {
    goto end;
end:
        return 1;
    }
    return 0;
}
```
c2go main.c
```
func _cgo_main() int32 {

	var t int32 = 's'
	var set *int32
	if !(t == 's') {
		goto _cgol_2
	}
	set = (*int32)(unsafe.Pointer(&_cgos_main_spaces_main))
	goto _cgol_1
_cgol_2:
	goto end
_cgol_1:
	if true {
		goto _cgol_3
	}
	goto end
end:
	return int32(1)
_cgol_3:
	return int32(0)
}

var _cgos_main_spaces_main [1]int32 = [1]int32{'\x00'}
```
