### PR TITLE
compileTypedef: alias type check in pkg scope

### DIFF
--- a/cl/type_and_var.go
+++ b/cl/type_and_var.go
@@ -229,7 +229,11 @@ func compileTypedef(ctx *blockCtx, decl *ast.Node, global, pub bool) types.Type 
 			}
 		}
 	}
-	ctx.cb.AliasType(name, typ, ctx.goNodePos(decl))
+	if scope == ctx.pkg.Types.Scope() {
+		ctx.cb.AliasType(name, typ, ctx.goNodePos(decl))
+	} else {
+		aliasType(scope, ctx.pkg.Types, name, typ)
+	}
 	return typ
 }
 

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -316,7 +316,6 @@ void test() {
 		a int32 = int32(3)
 		b int32 = 4
 	)
-	type foo = int32
 }`)
 }
 
@@ -334,9 +333,10 @@ void test() {
 	testFunc(t, "testValistTypedef", `
 void test() {
 	typedef __builtin_va_list foo;
+	foo a;
 }
 `, `func test() {
-	type foo = []interface {
+	var a []interface {
 	}
 }`)
 }
@@ -542,12 +542,13 @@ void test() {
 	typedef struct foo {
 		int a;
 	} foo;
+	foo a;
 }
 `, `func test() {
 	type struct_foo struct {
 		a int32
 	}
-	type foo = struct_foo
+	var a struct_foo
 }`)
 }
 


### PR DESCRIPTION
fix https://github.com/goplus/c2go/issues/162

remove type alias in func scope

main.c
```
int main() {
   int t = 's';
   const int *set;
   if (t == 's') {
      typedef int __attribute__((__may_alias__)) w32;
      const w32 spaces[] = {'\0'};
      set = spaces;
   } 
   return 0;
}
```
c2go main.c
```
func _cgo_main() int32 {
	var t int32 = 's'
	var set *int32
	if t == 's' {
		var spaces [1]int32 = [1]int32{'\x00'}
		set = (*int32)(unsafe.Pointer(&spaces))
	}
	return int32(0)
}
```