### PR TITLE
cl: compileExprEx support ast.PredefinedExpr

### DIFF
--- a/cl/expr.go
+++ b/cl/expr.go
@@ -72,6 +72,8 @@ func compileExprEx(ctx *blockCtx, expr *ast.Node, prompt string, flags int) {
 	case ast.VisibilityAttr:
 	case ast.CompoundLiteralExpr:
 		compileCompoundLiteralExpr(ctx, expr)
+	case ast.PredefinedExpr:
+		compileExpr(ctx, expr.Inner[0])
 	default:
 		log.Panicln(prompt, expr.Kind)
 	}

--- a/cl/type_and_var_test.go
+++ b/cl/type_and_var_test.go
@@ -637,4 +637,17 @@ void test() {
 }`)
 }
 
+func TestPredefined(t *testing.T) {
+	testFunc(t, "testPredefined", `
+void test() {
+	const char *func = __func__;
+	// const char *file = __FILE__;
+	const int line = __LINE__;
+}
+`, `func test() {
+	var func_ *int8 = (*int8)(unsafe.Pointer(&[5]int8{'t', 'e', 's', 't', '\x00'}))
+	const line int32 = int32(5)
+}`)
+}
+
 // -----------------------------------------------------------------------------

--- a/clang/ast/ast.go
+++ b/clang/ast/ast.go
@@ -119,6 +119,7 @@ const (
 	UnaryOperator            Kind = "UnaryOperator"
 	ConditionalOperator      Kind = "ConditionalOperator"
 	CompoundLiteralExpr      Kind = "CompoundLiteralExpr"
+	PredefinedExpr           Kind = "PredefinedExpr"
 	CharacterLiteral         Kind = "CharacterLiteral"
 	IntegerLiteral           Kind = "IntegerLiteral"
 	StringLiteral            Kind = "StringLiteral"


### PR DESCRIPTION
fix https://github.com/goplus/c2go/issues/174