### PR TITLE
cl: compileForStmt support multi init decl stmt

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -293,4 +293,53 @@ _cgol_3:
 }`)
 }
 
+func TestSimpleForStmt(t *testing.T) {
+	testFunc(t, "testSimpleFor1", `
+void printf(int,int);
+void test() {
+    int j = 0;
+    for (int i = 0; i < 5; ++i, j += 7)
+    {
+        printf(i,j);
+    }
+}
+`, `func test() {
+	var j int32 = int32(0)
+	for i := int32(int32(0)); i < int32(5); func() int32 {
+		i++
+		return func() (_cgo_ret int32) {
+			_cgo_addr := &j
+			*_cgo_addr += int32(7)
+			return *_cgo_addr
+		}()
+	}() {
+		printf(i, j)
+	}
+}`)
+	testFunc(t, "testSimpleFor2", `
+void printf(int,int);
+void test() {
+    for (int i = 0, j = 0; i < 5; ++i, j += 7)
+    {
+        printf(i,j);
+    }
+}
+`, `func test() {
+	{
+		var i int32 = int32(0)
+		var j int32 = int32(0)
+		for ; i < int32(5); func() int32 {
+			i++
+			return func() (_cgo_ret int32) {
+				_cgo_addr := &j
+				*_cgo_addr += int32(7)
+				return *_cgo_addr
+			}()
+		}() {
+			printf(i, j)
+		}
+	}
+}`)
+}
+
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
fix https://github.com/goplus/c2go/issues/176

main.c
```
int main() {
    for (int i = 0, j = 1; i < 5; ++i, j += 7)
    {
        printf("%d %d\n",i,j);
    }
    return 0;
}
```
Added a block and move init before forstmt if has multi init decl.
```
func _cgo_main() int32 {
	{
		var i int32 = int32(0)
		var j int32 = int32(1)
		for ; i < int32(5); func() int32 {
			i++
			return func() (_cgo_ret int32) {
				_cgo_addr := &j
				*_cgo_addr += int32(7)
				return *_cgo_addr
			}()
		}() {
			printf((*int8)(unsafe.Pointer(&[7]int8{'%', 'd', ' ', '%', 'd', '\n', '\x00'})), i, j)
		}
	}
	return int32(0)
}

```