### PR TITLE
ast.DisableTailCallsAttr ast.StaticAssertDecl and __builtin___ func

### DIFF
--- a/cl/codebuild.go
+++ b/cl/codebuild.go
@@ -28,6 +28,8 @@ const builtin_decls = `{
 	"__builtin___memmove_chk": "void* (void*, void*, size_t, size_t)",
 	"__builtin___strlcpy_chk": "size_t (char*, char*, size_t, size_t)",
 	"__builtin___strlcat_chk": "size_t (char*, char*, size_t, size_t)",
+	"__builtin___strncpy_chk": "char *(char *, const char *, size_t, size_t)",
+	"__builtin___snprintf_chk": "int (char *, size_t, int, size_t, const char *, ...)",
 	"__builtin_object_size": "size_t (void*, int32)",
 	"__builtin_fabsf": "float32 (float32)",
 	"__builtin_fabsl": "float64 (float64)",

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -400,7 +400,7 @@ func compileFunc(ctx *blockCtx, fn *ast.Node) {
 			ast.AlwaysInlineAttr, ast.WarnUnusedResultAttr, ast.NoThrowAttr, ast.NoInlineAttr, ast.AllocSizeAttr,
 			ast.NonNullAttr, ast.ConstAttr, ast.PureAttr, ast.GNUInlineAttr, ast.ReturnsTwiceAttr, ast.NoSanitizeAttr,
 			ast.RestrictAttr, ast.MSAllocatorAttr, ast.VisibilityAttr, ast.C11NoReturnAttr, ast.StrictFPAttr,
-			ast.AllocAlignAttr:
+			ast.AllocAlignAttr, ast.DisableTailCallsAttr:
 		default:
 			log.Panicln("compileFunc: unknown kind =", item.Kind)
 		}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -369,6 +369,8 @@ func compileDeclStmt(ctx *blockCtx, node *ast.Node, global bool) {
 				continue
 			}
 			fallthrough
+		case ast.StaticAssertDecl:
+			continue
 		default:
 			log.Panicln("compileDeclStmt: unknown kind =", decl.Kind)
 		}

--- a/clang/ast/ast.go
+++ b/clang/ast/ast.go
@@ -126,6 +126,7 @@ const (
 	FloatingLiteral          Kind = "FloatingLiteral"
 	ImaginaryLiteral         Kind = "ImaginaryLiteral"
 	AllocAlignAttr           Kind = "AllocAlignAttr"
+	DisableTailCallsAttr     Kind = "DisableTailCallsAttr"
 )
 
 type ValueCategory string

--- a/clang/ast/ast.go
+++ b/clang/ast/ast.go
@@ -127,6 +127,7 @@ const (
 	ImaginaryLiteral         Kind = "ImaginaryLiteral"
 	AllocAlignAttr           Kind = "AllocAlignAttr"
 	DisableTailCallsAttr     Kind = "DisableTailCallsAttr"
+	StaticAssertDecl         Kind = "StaticAssertDecl"
 )
 
 type ValueCategory string


### PR DESCRIPTION
- __attribute__:  __disable_tail_calls__
```
void __assert_rtn(const char *, const char *, int, const char *) __attribute__((__noreturn__)) __attribute__((__cold__)) __attribute__((__disable_tail_calls__));
```
- decl _Static_check
```
StaticAssertDecl
```
- builtin
```
"__builtin___strncpy_chk": "char *(char *, const char *, size_t, size_t)",
"__builtin___snprintf_chk": "int (char *, size_t, int, size_t, const char *, ...)",
```